### PR TITLE
Upgrade ncs to v2.6.1

### DIFF
--- a/subsys/mgmt/mcumgr/transport/src/smp_bt.c
+++ b/subsys/mgmt/mcumgr/transport/src/smp_bt.c
@@ -230,6 +230,8 @@ static void conn_param_smp_enable(struct bt_conn *conn)
 	}
 }
 
+bool rvmn_auth_is_authenticated(struct bt_conn *conn);
+
 /**
  * Write handler for the SMP characteristic; processes an incoming SMP request.
  */
@@ -239,6 +241,11 @@ static ssize_t smp_bt_chr_write(struct bt_conn *conn,
 				uint8_t flags)
 {
 	struct conn_param_data *cpd = conn_param_data_get(conn);
+
+	if (!rvmn_auth_is_authenticated(conn)) {
+		return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);
+	}
+	
 #ifdef CONFIG_MCUMGR_TRANSPORT_BT_REASSEMBLY
 	int ret;
 	bool started;

--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -30,14 +30,39 @@ config SETTINGS_DYNAMIC_HANDLERS
 config SETTINGS_ENCODE_LEN
 	bool
 
-choice SETTINGS_BACKEND
-	prompt "Storage back-end"
-	default SETTINGS_NVS if NVS
-	default SETTINGS_FCB if FCB
-	default SETTINGS_FILE if FILE_SYSTEM
-	default SETTINGS_NONE
+choice SETTINGS_STORAGE_DST
+	prompt "Storage back-end destination"
+	default SETTINGS_STORAGE_DST_FCB if SETTINGS_FCB
+	default SETTINGS_STORAGE_DST_FILE if SETTINGS_FILE
+	default SETTINGS_STORAGE_DST_NVS if SETTINGS_NVS
+	default SETTINGS_STORAGE_DST_NONE
+	depends on SETTINGS
 	help
-	  Storage back-end to be used by the settings subsystem.
+	  Storage destination back-end to be used by the settings subsystem.
+
+config SETTINGS_STORAGE_DST_FCB
+	bool "DST FCB"
+	depends on SETTINGS_FCB
+	help
+	  Use FCB as a settings storage destination back-end.
+
+config SETTINGS_STORAGE_DST_FILE
+	bool "DST FILE SYSTEM"
+	depends on SETTINGS_FILE
+	help
+	  Use FILE SYSTEM as a settings storage destination back-end.
+
+config SETTINGS_STORAGE_DST_NVS
+	bool "DST NVS"
+	depends on SETTINGS_NVS
+	help
+	  Use NVS as a settings storage destination back-end.
+
+config SETTINGS_STORAGE_DST_NONE
+	bool "DST FCB"
+	help
+	  No storage destination back-end.		
+endchoice
 
 config SETTINGS_FCB
 	bool "FCB"
@@ -94,7 +119,6 @@ config SETTINGS_NONE
 	bool "NONE"
 	help
 	  No storage back-end.
-endchoice
 
 config SETTINGS_FCB_NUM_AREAS
 	int "Number of flash areas used by the settings subsystem"

--- a/subsys/settings/include/settings/settings_fcb.h
+++ b/subsys/settings/include/settings/settings_fcb.h
@@ -23,6 +23,7 @@ struct settings_fcb {
 extern int settings_fcb_src(struct settings_fcb *cf);
 extern int settings_fcb_dst(struct settings_fcb *cf);
 void settings_mount_fcb_backend(struct settings_fcb *cf);
+int settings_fcb_backend_init(void);
 
 #ifdef __cplusplus
 }

--- a/subsys/settings/include/settings/settings_file.h
+++ b/subsys/settings/include/settings/settings_file.h
@@ -37,6 +37,8 @@ __deprecated static inline void settings_mount_fs_backend(struct settings_file *
 	settings_mount_file_backend(cf);
 }
 
+int settings_file_backend_init(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/settings/include/settings/settings_nvs.h
+++ b/subsys/settings/include/settings/settings_nvs.h
@@ -58,7 +58,7 @@ int settings_nvs_dst(struct settings_nvs *cf);
 
 /* Initialize a nvs backend. */
 int settings_nvs_backend_init(struct settings_nvs *cf);
-
+int settings_nv_backend_init(void);
 
 #ifdef __cplusplus
 }

--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -25,7 +25,7 @@ LOG_MODULE_DECLARE(settings, CONFIG_SETTINGS_LOG_LEVEL);
 
 #define SETTINGS_FCB_VERS		1
 
-int settings_backend_init(void);
+int settings_fcb_backend_init(void);
 
 static int settings_fcb_load(struct settings_store *cs,
 			     const struct settings_load_arg *arg);
@@ -122,7 +122,7 @@ static bool settings_fcb_check_duplicate(struct settings_fcb *cf,
 		char name2[SETTINGS_MAX_NAME_LEN + SETTINGS_EXTRA_LEN + 1];
 		size_t name2_len;
 
-		if (settings_line_name_read(name2, sizeof(name2), &name2_len,
+		if (settings_line_name_read(SETTINGS_STORAGE_FCB, name2, sizeof(name2), &name2_len,
 					    &entry2_ctx)) {
 			LOG_ERR("failed to load line");
 			continue;
@@ -161,7 +161,7 @@ static int settings_fcb_load_priv(struct settings_store *cs,
 		int rc2;
 		bool pass_entry = true;
 
-		rc2 = settings_line_name_read(name, sizeof(name), &name_len,
+		rc2 = settings_line_name_read(SETTINGS_STORAGE_FCB, name, sizeof(name), &name_len,
 					     (void *)&entry_ctx);
 		if (rc2) {
 			LOG_ERR("Failed to load line name: %d", rc2);
@@ -189,10 +189,16 @@ static int settings_fcb_load_priv(struct settings_store *cs,
 static int settings_fcb_load(struct settings_store *cs,
 			     const struct settings_load_arg *arg)
 {
+	struct settings_load_arg_w_storage_type load_arg;
+	load_arg.storage_type = SETTINGS_STORAGE_FCB;
+	load_arg.cb = arg->cb;
+	load_arg.param = arg->param;
+	load_arg.subtree = arg->subtree;
+
 	return settings_fcb_load_priv(
 		cs,
 		settings_line_load_cb,
-		(void *)arg,
+		(void *)&load_arg,
 		true);
 }
 
@@ -243,7 +249,7 @@ static void settings_fcb_compress(struct settings_fcb *cf)
 
 		size_t val1_off;
 
-		rc = settings_line_name_read(name1, sizeof(name1), &val1_off,
+		rc = settings_line_name_read(SETTINGS_STORAGE_FCB, name1, sizeof(name1), &val1_off,
 					     &loc1);
 		if (rc) {
 			continue;
@@ -262,7 +268,7 @@ static void settings_fcb_compress(struct settings_fcb *cf)
 		while (fcb_getnext(&cf->cf_fcb, &loc2.loc) == 0) {
 			size_t val2_off;
 
-			rc = settings_line_name_read(name2, sizeof(name2),
+			rc = settings_line_name_read(SETTINGS_STORAGE_FCB, name2, sizeof(name2),
 						     &val2_off, &loc2);
 			if (rc) {
 				continue;
@@ -286,7 +292,7 @@ static void settings_fcb_compress(struct settings_fcb *cf)
 			continue;
 		}
 
-		rc = settings_line_entry_copy(&loc2, 0, &loc1, 0,
+		rc = settings_line_entry_copy(SETTINGS_STORAGE_FCB, &loc2, 0, &loc1, 0,
 					      loc1.loc.fe_data_len);
 		if (rc) {
 			continue;
@@ -353,7 +359,7 @@ static int settings_fcb_save_priv(struct settings_store *cs, const char *name,
 
 	loc.fap = cf->cf_fcb.fap;
 
-	rc = settings_line_write(name, value, val_len, 0, (void *)&loc);
+	rc = settings_line_write(SETTINGS_STORAGE_FCB, name, value, val_len, 0, (void *)&loc);
 
 	if (rc != -EIO) {
 		i = fcb_append_finish(&cf->cf_fcb, &loc.loc);
@@ -380,6 +386,7 @@ static int settings_fcb_save(struct settings_store *cs, const char *name,
 	cdca.val = (char *)value;
 	cdca.is_dup = 0;
 	cdca.val_len = val_len;
+	cdca.storage_type = SETTINGS_STORAGE_FCB;
 	settings_fcb_load_priv(cs, settings_line_dup_check_cb, &cdca, false);
 	if (cdca.is_dup == 1) {
 		return 0;
@@ -392,11 +399,10 @@ void settings_mount_fcb_backend(struct settings_fcb *cf)
 	uint8_t rbs;
 
 	rbs = cf->cf_fcb.f_align;
-
-	settings_line_io_init(read_handler, write_handler, get_len_cb, rbs);
+	settings_line_io_init(read_handler, write_handler, get_len_cb, rbs, SETTINGS_STORAGE_FCB);
 }
 
-int settings_backend_init(void)
+int settings_fcb_backend_init(void)
 {
 	static struct flash_sector
 		settings_fcb_area[CONFIG_SETTINGS_FCB_NUM_AREAS + 1];
@@ -437,10 +443,12 @@ int settings_backend_init(void)
 		}
 	}
 
+#if defined(CONFIG_SETTINGS_STORAGE_DST_FCB)
 	rc = settings_fcb_dst(&config_init_settings_fcb);
 	if (rc != 0) {
 		return rc;
 	}
+#endif
 
 	settings_mount_fcb_backend(&config_init_settings_fcb);
 

--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -27,7 +27,7 @@ LOG_MODULE_DECLARE(settings, CONFIG_SETTINGS_LOG_LEVEL);
 #define SETTINGS_FILE_PATH		CONFIG_SETTINGS_FILE_PATH
 #endif
 
-int settings_backend_init(void);
+int settings_file_backend_init(void);
 
 static int settings_file_load(struct settings_store *cs,
 			      const struct settings_load_arg *arg);
@@ -87,7 +87,7 @@ static bool settings_file_check_duplicate(
 	struct line_entry_ctx entry2_ctx = *entry_ctx;
 
 	/* Searching the duplicates */
-	while (settings_next_line_ctx(&entry2_ctx) == 0) {
+	while (settings_next_line_ctx(SETTINGS_STORAGE_FILE, &entry2_ctx) == 0) {
 		char name2[SETTINGS_MAX_NAME_LEN + SETTINGS_EXTRA_LEN + 1];
 		size_t name2_len;
 
@@ -95,7 +95,7 @@ static bool settings_file_check_duplicate(
 			break;
 		}
 
-		if (settings_line_name_read(name2, sizeof(name2), &name2_len,
+		if (settings_line_name_read(SETTINGS_STORAGE_FILE, name2, sizeof(name2), &name2_len,
 					    &entry2_ctx)) {
 			continue;
 		}
@@ -148,12 +148,12 @@ static int settings_file_load_priv(struct settings_store *cs, line_load_cb cb,
 		size_t name_len;
 		bool pass_entry = true;
 
-		rc = settings_next_line_ctx(&entry_ctx);
+		rc = settings_next_line_ctx(SETTINGS_STORAGE_FILE, &entry_ctx);
 		if (rc || entry_ctx.len == 0) {
 			break;
 		}
 
-		rc = settings_line_name_read(name, sizeof(name), &name_len,
+		rc = settings_line_name_read(SETTINGS_STORAGE_FILE, name, sizeof(name), &name_len,
 					     &entry_ctx);
 
 		if (rc || name_len == 0) {
@@ -186,9 +186,15 @@ static int settings_file_load_priv(struct settings_store *cs, line_load_cb cb,
 static int settings_file_load(struct settings_store *cs,
 			      const struct settings_load_arg *arg)
 {
+	struct settings_load_arg_w_storage_type load_arg;
+	load_arg.storage_type = SETTINGS_STORAGE_FILE;
+	load_arg.cb = arg->cb;
+	load_arg.param = arg->param;
+	load_arg.subtree = arg->subtree;
+
 	return settings_file_load_priv(cs,
 				       settings_line_load_cb,
-				       (void *)arg,
+					   (void *)&load_arg,
 				       true);
 }
 
@@ -273,14 +279,14 @@ static int settings_file_save_and_compress(struct settings_file *cf,
 	new_name_len = strlen(name);
 
 	while (1) {
-		rc = settings_next_line_ctx(&loc1);
+		rc = settings_next_line_ctx(SETTINGS_STORAGE_FILE, &loc1);
 
 		if (rc || loc1.len == 0) {
 			/* try to amend new value to the compressed file */
 			break;
 		}
 
-		rc = settings_line_name_read(name1, sizeof(name1), &val1_off,
+		rc = settings_line_name_read(SETTINGS_STORAGE_FILE, name1, sizeof(name1), &val1_off,
 					     &loc1);
 		if (rc) {
 			/* try to process next line */
@@ -306,7 +312,7 @@ static int settings_file_save_and_compress(struct settings_file *cf,
 		while (1) {
 			size_t val2_off;
 
-			rc = settings_next_line_ctx(&loc2);
+			rc = settings_next_line_ctx(SETTINGS_STORAGE_FILE, &loc2);
 
 			if (rc || loc2.len == 0) {
 				/* try to amend new value to */
@@ -314,7 +320,7 @@ static int settings_file_save_and_compress(struct settings_file *cf,
 				break;
 			}
 
-			rc = settings_line_name_read(name2, sizeof(name2),
+			rc = settings_line_name_read(SETTINGS_STORAGE_FILE, name2, sizeof(name2),
 						     &val2_off, &loc2);
 			if (rc) {
 				/* try to process next line */
@@ -333,7 +339,7 @@ static int settings_file_save_and_compress(struct settings_file *cf,
 		loc2 = loc1;
 		loc2.len += 2;
 		loc2.seek -= 2;
-		rc = settings_line_entry_copy(&loc3, 0, &loc2, 0, loc2.len);
+		rc = settings_line_entry_copy(SETTINGS_STORAGE_FILE, &loc3, 0, &loc2, 0, loc2.len);
 		if (rc) {
 			/* compressed file might be corrupted */
 			goto end_rolback;
@@ -343,7 +349,7 @@ static int settings_file_save_and_compress(struct settings_file *cf,
 	}
 
 	/* at last store the new value */
-	rc = settings_line_write(name, value, val_len, 0, &loc3);
+	rc = settings_line_write(SETTINGS_STORAGE_FILE, name, value, val_len, 0, &loc3);
 	if (rc) {
 		/* compressed file might be corrupted */
 		goto end_rolback;
@@ -405,7 +411,7 @@ static int settings_file_save_priv(struct settings_store *cs, const char *name,
 		rc = fs_seek(&file, 0, FS_SEEK_END);
 		if (rc == 0) {
 			entry_ctx.stor_ctx = &file;
-			rc = settings_line_write(name, value, val_len, 0,
+			rc = settings_line_write(SETTINGS_STORAGE_FILE, name, value, val_len, 0,
 						  (void *)&entry_ctx);
 			if (rc == 0) {
 				cf->cf_lines++;
@@ -441,6 +447,7 @@ static int settings_file_save(struct settings_store *cs, const char *name,
 	cdca.val = (char *)value;
 	cdca.is_dup = 0;
 	cdca.val_len = val_len;
+	cdca.storage_type = SETTINGS_STORAGE_FILE;
 	settings_file_load_priv(cs, settings_line_dup_check_cb, &cdca, false);
 	if (cdca.is_dup == 1) {
 		return 0;
@@ -513,7 +520,7 @@ static int write_handler(void *ctx, off_t off, char const *buf, size_t len)
 
 void settings_mount_file_backend(struct settings_file *cf)
 {
-	settings_line_io_init(read_handler, write_handler, get_len_cb, 1);
+	settings_line_io_init(read_handler, write_handler, get_len_cb, 1, SETTINGS_STORAGE_FILE);
 }
 
 static int mkdir_if_not_exists(const char *path)
@@ -556,7 +563,7 @@ static int mkdir_for_file(const char *file_path)
 	return 0;
 }
 
-int settings_backend_init(void)
+int settings_file_backend_init(void)
 {
 	static struct settings_file config_init_settings_file = {
 		.cf_name = SETTINGS_FILE_PATH,
@@ -569,10 +576,12 @@ int settings_backend_init(void)
 		return rc;
 	}
 
+#if defined(CONFIG_SETTINGS_STORAGE_DST_FILE)
 	rc = settings_file_dst(&config_init_settings_file);
 	if (rc) {
 		return rc;
 	}
+#endif
 
 	settings_mount_file_backend(&config_init_settings_file);
 

--- a/subsys/settings/src/settings_init.c
+++ b/subsys/settings/src/settings_init.c
@@ -13,6 +13,8 @@
 
 #include <zephyr/settings/settings.h>
 #include "settings/settings_file.h"
+#include "settings/settings_fcb.h"
+#include "settings/settings_nvs.h"
 #include <zephyr/kernel.h>
 
 extern struct k_mutex settings_lock;
@@ -20,8 +22,6 @@ extern struct k_mutex settings_lock;
 bool settings_subsys_initialized;
 
 void settings_init(void);
-
-int settings_backend_init(void);
 
 int settings_subsys_init(void)
 {
@@ -33,8 +33,15 @@ int settings_subsys_init(void)
 	if (!settings_subsys_initialized) {
 		settings_init();
 
-		err = settings_backend_init();
-
+#if defined(CONFIG_SETTINGS_FCB)
+		err = settings_fcb_backend_init(); /* func rises kernel panic once error */
+#endif
+#if defined(CONFIG_SETTINGS_FILE)
+		err = settings_file_backend_init(); /* func rises kernel panic once error */
+#endif
+#if defined(CONFIG_SETTINGS_NVS)
+		err = settings_nv_backend_init(); /* func rises kernel panic once error */
+#endif
 		if (!err) {
 			settings_subsys_initialized = true;
 		}

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -471,5 +471,5 @@ int settings_line_load_cb(const char *name, void *val_read_cb_ctx, off_t off,
 	len = settings_line_val_get_len(arg_w_storage_type->storage_type, off, val_read_cb_ctx);
 
 	return settings_call_set_handler(name, len, settings_line_read_cb,
-					 &value_ctx, arg);
+					 &value_ctx, &arg);
 }

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -471,5 +471,5 @@ int settings_line_load_cb(const char *name, void *val_read_cb_ctx, off_t off,
 	len = settings_line_val_get_len(arg_w_storage_type->storage_type, off, val_read_cb_ctx);
 
 	return settings_call_set_handler(name, len, settings_line_read_cb,
-					 &value_ctx, &arg);
+					 &value_ctx, arg);
 }

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -21,7 +21,37 @@ struct settings_io_cb_s {
 	uint8_t rwbs;
 } static settings_io_cb;
 
-int settings_line_write(const char *name, const char *value, size_t val_len,
+#if defined(CONFIG_SETTINGS_FILE)
+static struct settings_io_cb_s settings_file_io_cb;
+#endif
+#if defined(CONFIG_SETTINGS_FCB)
+static struct settings_io_cb_s settings_fcb_io_cb;
+#endif
+
+#define MAX_ENC_BLOCK_SIZE 4
+
+static void settings_reset_io_cb(enum settings_storage_type storage_type)
+{
+#if defined(CONFIG_SETTINGS_FCB) 
+		if (storage_type == SETTINGS_STORAGE_FCB) {
+			settings_io_cb.read_cb = settings_fcb_io_cb.read_cb;
+			settings_io_cb.write_cb = settings_fcb_io_cb.write_cb;
+			settings_io_cb.get_len_cb = settings_fcb_io_cb.get_len_cb;
+			settings_io_cb.rwbs = settings_fcb_io_cb.rwbs;
+		} 
+#endif
+
+#if defined(CONFIG_SETTINGS_FILE)
+		if (storage_type == SETTINGS_STORAGE_FILE) {
+			settings_io_cb.read_cb = settings_file_io_cb.read_cb;
+			settings_io_cb.write_cb = settings_file_io_cb.write_cb;
+			settings_io_cb.get_len_cb = settings_file_io_cb.get_len_cb;
+			settings_io_cb.rwbs = settings_file_io_cb.rwbs;
+		}
+#endif
+}
+
+int settings_line_write(enum settings_storage_type storage_type, const char *name, const char *value, size_t val_len,
 			off_t w_loc, void *cb_arg)
 {
 	size_t w_size, rem, add;
@@ -30,6 +60,7 @@ int settings_line_write(const char *name, const char *value, size_t val_len,
 	char w_buf[32]; /* write buff, must be aligned either to minimal */
 			/* base64 encoding size and write-block-size */
 	int rc;
+	settings_reset_io_cb(storage_type);
 	uint8_t wbs = settings_io_cb.rwbs;
 #ifdef CONFIG_SETTINGS_ENCODE_LEN
 	uint16_t len_field;
@@ -38,32 +69,34 @@ int settings_line_write(const char *name, const char *value, size_t val_len,
 	rem = strlen(name);
 
 #ifdef CONFIG_SETTINGS_ENCODE_LEN
-	len_field = settings_line_len_calc(name, val_len);
-	memcpy(w_buf, &len_field, sizeof(len_field));
-	w_size = 0;
+	if (storage_type == SETTINGS_STORAGE_FILE) {
+		len_field = settings_line_len_calc(name, val_len);
+		memcpy(w_buf, &len_field, sizeof(len_field));
+		w_size = 0;
 
 
-	add = sizeof(len_field) % wbs;
-	if (add) {
-		w_size = wbs - add;
-		if (rem < w_size) {
-			w_size = rem;
+		add = sizeof(len_field) % wbs;
+		if (add) {
+			w_size = wbs - add;
+			if (rem < w_size) {
+				w_size = rem;
+			}
+
+			memcpy(w_buf + sizeof(len_field), name, w_size);
+			name += w_size;
+			rem -= w_size;
 		}
 
-		memcpy(w_buf + sizeof(len_field), name, w_size);
-		name += w_size;
-		rem -= w_size;
-	}
-
-	w_size += sizeof(len_field);
-	if (w_size % wbs == 0) {
-		rc = settings_io_cb.write_cb(cb_arg, w_loc, w_buf, w_size);
-		if (rc) {
-			return -EIO;
+		w_size += sizeof(len_field);
+		if (w_size % wbs == 0) {
+			rc = settings_io_cb.write_cb(cb_arg, w_loc, w_buf, w_size);
+			if (rc) {
+				return -EIO;
+			}
 		}
+		/* The Alternative to condition above mean that `rem == 0` as `name` */
+		/* must have been consumed					     */
 	}
-	/* The Alternative to condition above mean that `rem == 0` as `name` */
-	/* must have been consumed					     */
 #endif
 	w_size = rem - rem % wbs;
 	rem %= wbs;
@@ -120,7 +153,7 @@ int settings_line_write(const char *name, const char *value, size_t val_len,
 }
 
 #ifdef CONFIG_SETTINGS_ENCODE_LEN
-int settings_next_line_ctx(struct line_entry_ctx *entry_ctx)
+int settings_next_line_ctx(enum settings_storage_type storage_type, struct line_entry_ctx *entry_ctx)
 {
 	size_t len_read;
 	uint16_t readout;
@@ -130,7 +163,7 @@ int settings_next_line_ctx(struct line_entry_ctx *entry_ctx)
 
 	entry_ctx->len = 0; /* ask read handler to ignore len */
 
-	rc = settings_line_raw_read(0, (char *)&readout, sizeof(readout),
+	rc = settings_line_raw_read(storage_type, 0, (char *)&readout, sizeof(readout),
 			   &len_read, entry_ctx);
 	if (rc == 0) {
 		if (len_read != sizeof(readout)) {
@@ -169,13 +202,14 @@ int settings_line_len_calc(const char *name, size_t val_len)
  * @retval 0 on success,
  * -ERCODE on storage errors
  */
-static int settings_line_raw_read_until(off_t seek, char *out, size_t len_req,
+static int settings_line_raw_read_until(enum settings_storage_type storage_type, off_t seek, char *out, size_t len_req,
 				 size_t *len_read, char const *until_char,
 				 void *cb_arg)
 {
 	size_t rem_size, len;
 	char temp_buf[32]; /* buffer for fit read-block-size requirements */
 	size_t exp_size, read_size;
+	settings_reset_io_cb(storage_type);
 	uint8_t rbs = settings_io_cb.rwbs;
 	off_t off;
 	int rc = -EINVAL;
@@ -231,25 +265,25 @@ static int settings_line_raw_read_until(off_t seek, char *out, size_t len_req,
 	return 0;
 }
 
-int settings_line_raw_read(off_t seek, char *out, size_t len_req,
+int settings_line_raw_read(enum settings_storage_type storage_type, off_t seek, char *out, size_t len_req,
 			   size_t *len_read, void *cb_arg)
 {
-	return settings_line_raw_read_until(seek, out, len_req, len_read,
+	return settings_line_raw_read_until(storage_type, seek, out, len_req, len_read,
 					    NULL, cb_arg);
 }
 
 /* off from value begin */
-int settings_line_val_read(off_t val_off, off_t off, char *out, size_t len_req,
+int settings_line_val_read(enum settings_storage_type storage_type, off_t val_off, off_t off, char *out, size_t len_req,
 			   size_t *len_read, void *cb_arg)
 {
-	return settings_line_raw_read(val_off + off, out, len_req, len_read,
+	return settings_line_raw_read(storage_type, val_off + off, out, len_req, len_read,
 				      cb_arg);
 }
 
-size_t settings_line_val_get_len(off_t val_off, void *read_cb_ctx)
+size_t settings_line_val_get_len(enum settings_storage_type storage_type, off_t val_off, void *read_cb_ctx)
 {
 	size_t len;
-
+	settings_reset_io_cb(storage_type);
 	len = settings_io_cb.get_len_cb(read_cb_ctx);
 
 	return len - val_off;
@@ -262,22 +296,24 @@ size_t settings_line_val_get_len(off_t val_off, void *read_cb_ctx)
  * 1 : when read unproper name
  * -ERCODE for storage errors
  */
-int settings_line_name_read(char *out, size_t len_req, size_t *len_read,
+int settings_line_name_read(enum settings_storage_type storage_type, char *out, size_t len_req, size_t *len_read,
 			    void *cb_arg)
 {
 	char const until_char = '=';
 
-	return settings_line_raw_read_until(0, out, len_req, len_read,
+	return settings_line_raw_read_until(storage_type, 0, out, len_req, len_read,
 					    &until_char, cb_arg);
 }
 
 
-int settings_line_entry_copy(void *dst_ctx, off_t dst_off, void *src_ctx,
+int settings_line_entry_copy(enum settings_storage_type storage_type, void *dst_ctx, off_t dst_off, void *src_ctx,
 			     off_t src_off, size_t len)
 {
 	int rc = -EINVAL;
 	char buf[16];
 	size_t chunk_size;
+
+	settings_reset_io_cb(storage_type);
 
 	while (len) {
 		chunk_size = MIN(len, sizeof(buf));
@@ -313,17 +349,30 @@ void settings_line_io_init(int (*read_cb)(void *ctx, off_t off, char *buf,
 			  int (*write_cb)(void *ctx, off_t off, char const *buf,
 					  size_t len),
 			  size_t (*get_len_cb)(void *ctx),
-			  uint8_t io_rwbs)
+			  uint8_t io_rwbs,
+			  enum settings_storage_type storage_type)
 {
-	settings_io_cb.read_cb = read_cb;
-	settings_io_cb.write_cb = write_cb;
-	settings_io_cb.get_len_cb = get_len_cb;
-	settings_io_cb.rwbs = io_rwbs;
+#if defined(CONFIG_SETTINGS_FCB)
+		if (storage_type == SETTINGS_STORAGE_FCB) {
+			settings_fcb_io_cb.read_cb = read_cb;
+			settings_fcb_io_cb.write_cb = write_cb;
+			settings_fcb_io_cb.get_len_cb = get_len_cb;
+			settings_fcb_io_cb.rwbs = io_rwbs;
+		} 
+#endif
+#if defined(CONFIG_SETTINGS_FILE)
+		if (storage_type == SETTINGS_STORAGE_FILE) {
+			settings_file_io_cb.read_cb = read_cb;
+			settings_file_io_cb.write_cb = write_cb;
+			settings_file_io_cb.get_len_cb = get_len_cb;
+			settings_file_io_cb.rwbs = io_rwbs;
+		}
+#endif
 }
 
 
 /* val_off - offset of value-string within line entries */
-static int settings_line_cmp(char const *val, size_t val_len,
+static int settings_line_cmp(enum settings_storage_type storage_type, char const *val, size_t val_len,
 			     void *val_read_cb_ctx, off_t val_off)
 {
 	size_t len_read, exp_len;
@@ -338,7 +387,7 @@ static int settings_line_cmp(char const *val, size_t val_len,
 
 	for (rem = val_len; rem > 0; rem -= len_read) {
 		len_read = exp_len = MIN(sizeof(buf), rem);
-		rc = settings_line_val_read(val_off, off, buf, len_read,
+		rc = settings_line_val_read(storage_type, val_off, off, buf, len_read,
 					    &len_read, val_read_cb_ctx);
 		if (rc) {
 			break;
@@ -363,21 +412,20 @@ static int settings_line_cmp(char const *val, size_t val_len,
 int settings_line_dup_check_cb(const char *name, void *val_read_cb_ctx,
 				off_t off, void *cb_arg)
 {
-	struct settings_line_dup_check_arg *cdca;
+	struct settings_line_dup_check_arg *cdca = (struct settings_line_dup_check_arg *)cb_arg;
 	size_t len_read;
 
-	cdca = (struct settings_line_dup_check_arg *)cb_arg;
 	if (strcmp(name, cdca->name)) {
 		return 0;
 	}
 
-	len_read = settings_line_val_get_len(off, val_read_cb_ctx);
+	len_read = settings_line_val_get_len(cdca->storage_type, off, val_read_cb_ctx);
 	if (len_read != cdca->val_len) {
 		cdca->is_dup = 0;
 	} else if (len_read == 0) {
 		cdca->is_dup = 1;
 	} else {
-		if (!settings_line_cmp(cdca->val, cdca->val_len,
+		if (!settings_line_cmp(cdca->storage_type, cdca->val, cdca->val_len,
 				       val_read_cb_ctx, off)) {
 			cdca->is_dup = 1;
 		} else {
@@ -393,7 +441,7 @@ static ssize_t settings_line_read_cb(void *cb_arg, void *data, size_t len)
 	size_t len_read;
 	int rc;
 
-	rc = settings_line_val_read(value_context->off, 0, data, len,
+	rc = settings_line_val_read(value_context->storage_type, value_context->off, 0, data, len,
 				    &len_read,
 				    value_context->read_cb_ctx);
 
@@ -409,11 +457,19 @@ int settings_line_load_cb(const char *name, void *val_read_cb_ctx, off_t off,
 {
 	size_t len;
 	struct settings_line_read_value_cb_ctx value_ctx;
-	struct settings_load_arg *arg = cb_arg;
+	struct settings_load_arg_w_storage_type *arg_w_storage_type = cb_arg;
+
+	struct settings_load_arg arg;
+	arg.cb = arg_w_storage_type->cb;
+	arg.param = arg_w_storage_type->param;
+	arg.subtree = arg_w_storage_type->subtree;
+
 	value_ctx.read_cb_ctx = val_read_cb_ctx;
 	value_ctx.off = off;
-	len = settings_line_val_get_len(off, val_read_cb_ctx);
+	value_ctx.storage_type = arg_w_storage_type->storage_type;
+
+	len = settings_line_val_get_len(arg_w_storage_type->storage_type, off, val_read_cb_ctx);
 
 	return settings_call_set_handler(name, len, settings_line_read_cb,
-					 &value_ctx, arg);
+					 &value_ctx, &arg);
 }

--- a/subsys/settings/src/settings_none.c
+++ b/subsys/settings/src/settings_none.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-int settings_backend_init(void)
+int settings_none_backend_init(void)
 {
 	return 0;
 }

--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -382,7 +382,7 @@ int settings_nvs_backend_init(struct settings_nvs *cf)
 	return 0;
 }
 
-int settings_backend_init(void)
+int settings_nv_backend_init(void)
 {
 	static struct settings_nvs default_settings_nvs;
 	int rc;
@@ -435,7 +435,9 @@ int settings_backend_init(void)
 		return rc;
 	}
 
+#if defined(CONFIG_SETTINGS_STORAGE_DST_NVS)
 	rc = settings_nvs_dst(&default_settings_nvs);
+#endif
 
 	return rc;
 }


### PR DESCRIPTION
update to ncs2.6.1 
Modifying Zephyr code to suit Setec's purposes.
Basically repeating the hacks that were done by Julian in commit: 

https://github.com/Setec-BMPRO/sdk-zephyr/commit/7ffd585772670db0c64b7bf7a042c93e14e353f7
